### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/alexreyes/71e4c7f5-b7bb-4be3-91af-c7b87a8b8ef8/666cd906-4535-4691-a26b-45890af89229/_apis/work/boardbadge/18fe27dd-ed6e-4adc-adc3-ee4e40d83f86)](https://dev.azure.com/alexreyes/71e4c7f5-b7bb-4be3-91af-c7b87a8b8ef8/_boards/board/t/666cd906-4535-4691-a26b-45890af89229/Microsoft.RequirementCategory)
 # FristClass
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 11.2.2.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/alexreyes/71e4c7f5-b7bb-4be3-91af-c7b87a8b8ef8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.